### PR TITLE
OEM driver should not be installed on macOS Mojave or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # ch340g-ch34g-ch34x-mac-os-x-driver
 Latest **macOS Sierra/High Sierra**-compatible driver for devices using the CH340G, CH34G or CH34X chipset. This chipset is used in several Arduino-compatible clones and serial-to-USB cables.
 
+**Do not install if you have the current macOS Mojave 10.14 or later.** macOS Mojave 10.14 (released in October 2018) includes a CH34x driver by Apple. If both Apple's and the OEM driver are installed, they will create conflicting non-functional serial ports. Steps 1 to 3 below can be useful to remove the conflicting OEM drivers.
+
+If you use Apple's driver and have problems with the serial communication, ensure the data rate is 460,800 bps or lower.
+
 ## Introduction
 Version 1.5 (2018-07-05) of the [OEM driver](http://www.wch.cn/download/CH341SER_MAC_ZIP.html) for the CH34x chipset.
 


### PR DESCRIPTION
macOS Mojave includes a CH34x driver (from Apple). Therefore the OEM driver is no longer needed. In fact, it causes problems. When a device with a CH34x chip is plugged in, two serial ports are created and one of them will be non-functional as it is blocked by the other one.

I propose to add a warning at the top of the README.

The Apple driver can be found at /System/Library/Extensions/AppleUSBCHCOM.kext/.